### PR TITLE
Add markdownlint workflow

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,20 @@
+name: Markdown lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
+      - name: Run markdownlint
+        run: markdownlint '**/*.md'


### PR DESCRIPTION
## Summary
- introduce markdownlint GitHub Actions workflow to lint all markdown files

## Testing
- `npx markdownlint '**/*.md'` *(fails: 403 Forbidden due to network restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6858ea8bbcc083249a48364b5243b7cd)